### PR TITLE
(WIP) Add an initial state to modules

### DIFF
--- a/DataflowRewriter/Component.lean
+++ b/DataflowRewriter/Component.lean
@@ -22,7 +22,8 @@ namespace DataflowRewriter.NatModule
     init_state := λ s => s = [],
   }
 
-@[drunfold] def merge_inputs {S} (mod : NatModule S) (in1 in2 : InternalPort Nat) : Option (NatModule S)  := do
+@[drunfold]
+def merge_inputs {S} (mod : NatModule S) (in1 in2 : InternalPort Nat) : Option (NatModule S)  := do
   let in1_t ← mod.inputs.find? in1
   let in2_t ← mod.inputs.find? in2
   let rmin2 := mod.inputs.erase in2
@@ -34,7 +35,8 @@ namespace DataflowRewriter.NatModule
     init_state := mod.init_state,
   }
 
-@[drunfold] def merge_outputs {S} (mod : NatModule S) (out1 out2 : InternalPort Nat) : Option (NatModule S)  := do
+@[drunfold]
+def merge_outputs {S} (mod : NatModule S) (out1 out2 : InternalPort Nat) : Option (NatModule S) := do
   let out1_t ← mod.outputs.find? out1
   let out2_t ← mod.outputs.find? out2
   let rmout2 := mod.outputs.erase out2
@@ -73,7 +75,8 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
     init_state := λ s => s = [],
   }
 
-@[drunfold] def cntrl_merge T (name : String := "cntrl_merge") : NatModule (Named name (List T × List Bool)) :=
+@[drunfold]
+def cntrl_merge T (name : String := "cntrl_merge") : NatModule (Named name (List T × List Bool)) :=
   {
     inputs := [ (0, ⟨ T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
                     newListL = oldListL.concat newElement ∧ newListR = oldListR.concat true ⟩)
@@ -88,7 +91,8 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def cntrl_merge_n T (n : Nat) (name : String := "cntrl_merge_n") : NatModule (Named name (List T × List Nat)) :=
+@[drunfold]
+def cntrl_merge_n T (n : Nat) (name : String := "cntrl_merge_n") : NatModule (Named name (List T × List Nat)) :=
   {
     inputs := List.range n |>.map (Prod.mk ↑· (⟨ T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
                 newListL = oldListL.concat newElement ∧ newListR = oldListR.concat n ⟩)) |>.toAssocList,
@@ -105,7 +109,8 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
 --     outputs := List.range n |>.map (Prod.mk ↑· ⟨ T, λ oldList oldElement newList => oldElement :: newList = oldList⟩) |>.toAssocList
 --   }
 
-@[drunfold] def fork2 T (name := "fork2") : NatModule (Named name (List T × List T)) :=
+@[drunfold]
+def fork2 T (name := "fork2") : NatModule (Named name (List T × List T)) :=
   {
     inputs := [
       (0, ⟨ T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
@@ -147,7 +152,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = [],
   }
 
-@[drunfold] def init T (default : T) (name := "init") : NatModule (Named name (List T × Bool)) :=
+@[drunfold]
+def init T (default : T) (name := "init") : NatModule (Named name (List T × Bool)) :=
   {
     inputs := [
       (0, ⟨ T, λ (oldList, oldState) newElement (newList, newState) =>
@@ -162,7 +168,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := sorry,
   }
 
-@[drunfold] def join T T' (name := "join") : NatModule (Named name (List T × List T')) :=
+@[drunfold]
+def join T T' (name := "join") : NatModule (Named name (List T × List T')) :=
   {
     inputs := [
       (0, ⟨ T, λ ol el nl => nl.1 = ol.1.concat el ∧ nl.2 = ol.2⟩),
@@ -171,10 +178,11 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     outputs := [
       (0, ⟨ T × T', λ ol el nl => ol.1 = el.1 :: nl.1 ∧ ol.2 = el.2 :: nl.2 ⟩),
     ].toAssocList
-    init_state := sorry,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def split T T' (name := "split") : NatModule (Named name (List T × List T')) :=
+@[drunfold]
+def split T T' (name := "split") : NatModule (Named name (List T × List T')) :=
   {
     inputs := [
       (0, ⟨ T × T', λ (oldListL, oldListR) (newElementL, newElementR) (newListL, newListR) =>
@@ -189,7 +197,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def branch T (name := "branch") : NatModule (Named name (List T × List Bool)) :=
+@[drunfold]
+def branch T (name := "branch") : NatModule (Named name (List T × List Bool)) :=
   {
     inputs := [
       (0, ⟨ T, λ (oldValList, oldBoolList) val (newValList, newBoolList) =>
@@ -206,7 +215,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def mux T (name := "mux") : NatModule (Named name (List T × List T × List Bool)) :=
+@[drunfold]
+def mux T (name := "mux") : NatModule (Named name (List T × List T × List Bool)) :=
   {
     inputs := [
       (2, ⟨ T, λ (oldTrueList, oldFalseList, oldBoolList) val (newTrueList, newFalseList, newBoolList) =>
@@ -225,7 +235,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = ⟨[], [], []⟩,
   }
 
-@[drunfold] def muxC T (name := "muxC") : NatModule (Named name (List T × List T × List Bool)) :=
+@[drunfold]
+def muxC T (name := "muxC") : NatModule (Named name (List T × List T × List Bool)) :=
   {
     inputs := [
       (2, ⟨ T, λ (oldTrueList, oldFalseList, oldBoolList) val (newTrueList, newFalseList, newBoolList) =>
@@ -244,7 +255,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = ⟨[], [], []⟩,
   }
 
-@[drunfold] def joinC T T' T'' (name := "joinC") : NatModule (Named name (List T × List (T'× T''))) :=
+@[drunfold]
+def joinC T T' T'' (name := "joinC") : NatModule (Named name (List T × List (T'× T''))) :=
   {
     inputs := [
       (0, ⟨ T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
@@ -277,7 +289,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     init_state := λ s => s = [],
   }
 
-@[drunfold] def tagger_untagger (TagT : Type 0) [_i: DecidableEq TagT] (T : Type 0) (name := "tagger_untagger") : NatModule (Named name (List TagT × (AssocList TagT T))) :=
+@[drunfold]
+def tagger_untagger (TagT : Type 0) [_i: DecidableEq TagT] (T : Type 0) (name := "tagger_untagger") : NatModule (Named name (List TagT × (AssocList TagT T))) :=
   {
     inputs := [
       -- Complete computation
@@ -305,7 +318,8 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
 /--
 Essentially tagger + join without internal rule
 -/
-@[drunfold] def tagger_untagger_val (TagT : Type 0) [_i: DecidableEq TagT] (T T' : Type 0) (name := "tagger_untagger_val") : NatModule (Named name (List TagT × AssocList TagT T' × List T)) :=
+@[drunfold]
+def tagger_untagger_val (TagT : Type 0) [_i: DecidableEq TagT] (T T' : Type 0) (name := "tagger_untagger_val") : NatModule (Named name (List TagT × AssocList TagT T' × List T)) :=
   {
     inputs := [
       -- Complete computation
@@ -337,7 +351,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], AssocList.nil, []⟩,
   }
 
-@[drunfold] def tagger (TagT : Type) [DecidableEq TagT] T (name := "tagger") : NatModule (Named name (List (TagT × T) × List TagT)) :=
+@[drunfold]
+def tagger (TagT : Type) [DecidableEq TagT] T (name := "tagger") : NatModule (Named name (List (TagT × T) × List TagT)) :=
   {
     inputs := [
       -- Allocate tag
@@ -354,7 +369,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def aligner TagT [DecidableEq TagT] T (name := "aligner") : NatModule (Named name (List (TagT × T) × List (TagT × T))) :=
+@[drunfold]
+def aligner TagT [DecidableEq TagT] T (name := "aligner") : NatModule (Named name (List (TagT × T) × List (TagT × T))) :=
   {
     inputs := [
       (0, ⟨ TagT × T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
@@ -372,14 +388,16 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def sink (T : Type _) (name := "sink") : NatModule (Named name Unit) :=
+@[drunfold]
+def sink (T : Type _) (name := "sink") : NatModule (Named name Unit) :=
   {
     inputs := [(0, ⟨ T, λ _ _ _ => True ⟩)].toAssocList,
     outputs := ∅
     init_state := λ _ => True,
   }
 
-@[drunfold] def unary_op {α R} (f : α → R) (name := "unary_op"): NatModule (Named name (List α)) :=
+@[drunfold]
+def unary_op {α R} (f : α → R) (name := "unary_op"): NatModule (Named name (List α)) :=
   {
     inputs := [
       (0, ⟨ α, λ oldList newElement newList => newList = oldList.concat newElement ⟩)
@@ -390,7 +408,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = [],
   }
 
-@[drunfold] def binary_op {α β R} (f : α → β → R) (name := "binary_op"): NatModule (Named name (List α × List β)) :=
+@[drunfold]
+def binary_op {α β R} (f : α → β → R) (name := "binary_op"): NatModule (Named name (List α × List β)) :=
   {
     inputs := [
         (0, ⟨ α, λ ol el nl => nl.1 = ol.1.concat el ∧ nl.2 = ol.2 ⟩),
@@ -403,7 +422,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def ternary_op {α β γ R} (f : α → β → γ → R) (name := "ternary_op"): NatModule (Named name (List α × List β × List γ)) :=
+@[drunfold]
+def ternary_op {α β γ R} (f : α → β → γ → R) (name := "ternary_op"): NatModule (Named name (List α × List β × List γ)) :=
   {
     inputs := [
       (0, ⟨ α, λ ol el nl => nl.1 = ol.1.concat el ∧ nl.2 = ol.2 ⟩),
@@ -417,7 +437,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], [], []⟩
   }
 
-@[drunfold] def constant {T} (t : T) (name := "constant") : NatModule (Named name (List Unit)) :=
+@[drunfold]
+def constant {T} (t : T) (name := "constant") : NatModule (Named name (List Unit)) :=
   {
     inputs := [
       (0, ⟨ Unit, λ oldList newElement newList => newList = oldList.concat newElement ⟩)
@@ -428,7 +449,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = [],
   }
 
-@[drunfold] def sync {T S} (name := "sync") : NatModule (Named name (List S × List T)) :=
+@[drunfold]
+def sync {T S} (name := "sync") : NatModule (Named name (List S × List T)) :=
   {
     inputs := [
       (0, ⟨ S, λ (lo, ro) s (ln, rn) => lo.concat s = ln ∧ ro = rn ⟩),
@@ -440,7 +462,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def sync1 {T S} (name := "sync1") : NatModule (Named name (Option S × List T)) :=
+@[drunfold]
+def sync1 {T S} (name := "sync1") : NatModule (Named name (Option S × List T)) :=
   {
     inputs := [
       (0, ⟨ S, λ (lo, ro) s (ln, rn) => lo = none ∧ ln = some s ∧ ro = rn ⟩),
@@ -452,7 +475,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨none, []⟩,
   }
 
-@[drunfold] def dsync {T S} (f : T → S) (name := "dsync") : NatModule (Named name (List S × List T)) :=
+@[drunfold]
+def dsync {T S} (f : T → S) (name := "dsync") : NatModule (Named name (List S × List T)) :=
   {
     inputs := [
         (0, ⟨ T, λ (lo, ro) t (ln, rn) => lo.concat (f t) = ln ∧ ro.concat t = rn ⟩),
@@ -464,10 +488,12 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def dsyncU {T} (name := "dsyncU") : NatModule (Named name (List Unit × List T)) :=
+@[drunfold]
+def dsyncU {T} (name := "dsyncU") : NatModule (Named name (List Unit × List T)) :=
   dsync (λ _ => ())
 
-@[drunfold] def dsync1 {T S} (f : T → S) (name := "dsync1") : NatModule (Named name (Option S × List T)) :=
+@[drunfold]
+def dsync1 {T S} (f : T → S) (name := "dsync1") : NatModule (Named name (Option S × List T)) :=
   {
     inputs := [
       (0, ⟨ T, λ (lo, ro) t (ln, rn) => lo = none ∧ ln = some (f t) ∧ ro.concat t = rn ⟩),
@@ -479,10 +505,12 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨none, []⟩,
   }
 
-@[drunfold] def dsync1U {T} (name := "dsync1U") : NatModule (Named name (Option Unit × List T)) :=
+@[drunfold]
+def dsync1U {T} (name := "dsync1U") : NatModule (Named name (Option Unit × List T)) :=
   dsync1 (λ _ => ()) (name := name)
 
-@[drunfold] def load S T (name := "load") : NatModule (Named name (List S × List T)) :=
+@[drunfold]
+def load S T (name := "load") : NatModule (Named name (List S × List T)) :=
   {
     inputs := [
       (0, ⟨S, λ before el after => after.1 = before.1.concat el ∧ after.2 = before.2⟩),
@@ -495,7 +523,8 @@ Essentially tagger + join without internal rule
     init_state := λ s => s = ⟨[], []⟩,
   }
 
-@[drunfold] def pure {S T} (f : S → T) (name := "pure") : NatModule (Named name (List T)) :=
+@[drunfold]
+def pure {S T} (f : S → T) (name := "pure") : NatModule (Named name (List T)) :=
   {
     inputs := [
       (0, ⟨S, λ before el after => after = before.concat (f el)⟩)
@@ -551,7 +580,10 @@ namespace FixedSize
 
 def BoundedList T n := { ls : List T // ls.length <= n }
 
-@[drunfold] def join T T' n : NatModule (BoundedList T n × BoundedList T' n) :=
+def BoundedList.empty T n : BoundedList T n := ⟨[], by simpa⟩
+
+@[drunfold]
+def join T T' n : NatModule (BoundedList T n × BoundedList T' n) :=
   {
     inputs := [
       (0, ⟨ T, λ (oldListL, oldListR) newElement (newListL, newListR) =>
@@ -564,10 +596,11 @@ def BoundedList T n := { ls : List T // ls.length <= n }
         oldListL.val = newListL.val.concat oldElementL
         ∧ oldListR.val = newListR.val.concat oldElementR ⟩)
     ].toAssocList,
-    init_state := sorry,
+    init_state := λ s => s = ⟨BoundedList.empty T n, BoundedList.empty T' n⟩,
   }
 
-@[drunfold] def joinL T T' T'' n : NatModule (BoundedList (T × T') n × BoundedList T'' n) :=
+@[drunfold]
+def joinL T T' T'' n : NatModule (BoundedList (T × T') n × BoundedList T'' n) :=
   {
     inputs := [
       (0, ⟨ T × T', λ (oldListL, oldListR) newElement (newListL, newListR) =>
@@ -580,7 +613,10 @@ def BoundedList T n := { ls : List T // ls.length <= n }
         oldListL.val = newListL.val.concat (oldElementL₁, oldElementL₂)
         ∧ oldListR.val = newListR.val.concat oldElementR⟩)
     ].toAssocList,
-    init_state := sorry,
+    init_state := λ s => s = ⟨
+      BoundedList.empty (T × T') n,
+      BoundedList.empty T'' n
+    ⟩,
   }
 
 end FixedSize
@@ -597,8 +633,6 @@ namespace DataflowRewriter.StringModule
 
 @[drunfold] def merge' T n := NatModule.merge' T n |>.stringify
 
--- @[drunfold] def fork T n := NatModule.fork T n |>.stringify
-
 @[drunfold] def fork T n := NatModule.fork T n |>.stringify
 
 @[drunfold] def cntrl_merge T := NatModule.cntrl_merge T |>.stringify
@@ -613,8 +647,7 @@ namespace DataflowRewriter.StringModule
 
 @[drunfold] def sink T := NatModule.sink T |>.stringify
 
-@[drunfold] def branch T := NatModule.branch T
-  |>.stringify
+@[drunfold] def branch T := NatModule.branch T |>.stringify
   -- |>.mapIdent (λ | 0 => "val" | _ => "cond") (λ | 0 => "true" | _ => "false")
 
 @[drunfold] def mux T := NatModule.mux T
@@ -721,8 +754,7 @@ def ε (Tag : Type) [DecidableEq Tag] (T : Type) [Inhabited T] : Env :=
   -- , ("Sub", ⟨_, StringModule.binary_op (@polymorphic_sub T _)⟩)
   ].toAssocList
 
-@[drunfold] def muxC T := NatModule.muxC T
-  |>.stringify
+@[drunfold] def muxC T := NatModule.muxC T |>.stringify
 
 @[drunfold] def joinC T T' T'' := NatModule.joinC T T' T'' |>.stringify
 

--- a/DataflowRewriter/Component.lean
+++ b/DataflowRewriter/Component.lean
@@ -19,7 +19,7 @@ namespace DataflowRewriter.NatModule
   {
     inputs := [(0, ⟨ T, λ s tt s' => s' = s.concat tt ⟩)].toAssocList,
     outputs := [(0, ⟨ T, λ s tt s' => s = tt :: s' ⟩)].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def merge_inputs {S} (mod : NatModule S) (in1 in2 : InternalPort Nat) : Option (NatModule S)  := do
@@ -31,7 +31,7 @@ namespace DataflowRewriter.NatModule
       ∃ s_int, in1_t.2 s v1 s_int ∧ in2_t.2 s_int v2 s'⟩,
     outputs := mod.outputs,
     internals := mod.internals,
-    initial_state := mod.initial_state,
+    init_state := mod.init_state,
   }
 
 @[drunfold] def merge_outputs {S} (mod : NatModule S) (out1 out2 : InternalPort Nat) : Option (NatModule S)  := do
@@ -43,7 +43,7 @@ namespace DataflowRewriter.NatModule
     outputs := rmout2.cons out2 ⟨ out1_t.1 × out2_t.1, λ s (v1,v2) s' =>
       ∃ s_int, out1_t.2 s v1 s_int ∧ out2_t.2 s_int v2 s' ⟩,
     internals := mod.internals,
-    initial_state := mod.initial_state,
+    init_state := mod.init_state,
   }
 
 abbrev Named (s : String) (T : Type _) := T
@@ -57,7 +57,7 @@ abbrev Named (s : String) (T : Type _) := T
       (0, ⟨ T, λ oldList oldElement newList =>
         ∃ i, newList = oldList.remove i ∧ oldElement = oldList.get i ⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 -- Strictest definition of a merge, where input are totally ordered
@@ -70,7 +70,7 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
     outputs := [
       (0, ⟨ T, λ oldList oldElement newList => oldList = oldElement :: newList⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def cntrl_merge T (name : String := "cntrl_merge") : NatModule (Named name (List T × List Bool)) :=
@@ -85,7 +85,7 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
                , (1, ⟨ Bool, λ (oldListL, oldListR) oldElement (newListL, newListR) =>
                     oldElement :: newListR = oldListR ∧ newListL = oldListL ⟩)
                ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def cntrl_merge_n T (n : Nat) (name : String := "cntrl_merge_n") : NatModule (Named name (List T × List Nat)) :=
@@ -97,7 +97,7 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
                , (1, ⟨ Nat, λ (oldListL, oldListR) oldElement (newListL, newListR) =>
                        oldElement :: newListR = oldListR ∧ newListL = oldListL ⟩)
                ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 -- @[drunfold] def fork T (n : Nat) : NatModule (Named name (List T)) :=
@@ -117,7 +117,7 @@ def merge' T (n : Nat) (name : String := "merge'") : NatModule (Named name (List
       (1, ⟨ T, λ (oldListL, oldListR) oldElement (newListL, newListR) =>
         oldElement :: newListR = oldListR ∧ newListL = oldListL ⟩),
     ] |>.toAssocList
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 def push_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
@@ -133,7 +133,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
         λ ind => (↑ind, ⟨ T, λ ol el nl =>
           .some ol = cons_n ind nl el
       ⟩)) |>.toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def queue T (name := "queue") : NatModule (Named name (List T)) :=
@@ -144,7 +144,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     outputs := [
       (0, ⟨ T, λ oldList oldElement newList =>  oldElement :: newList = oldList ⟩)
     ].toAssocList
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def init T (default : T) (name := "init") : NatModule (Named name (List T × Bool)) :=
@@ -159,7 +159,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
       else
         newList = oldList ∧ newState = true ∧ oldElement = default ⟩)
     ].toAssocList,
-    initial_state := sorry,
+    init_state := sorry,
   }
 
 @[drunfold] def join T T' (name := "join") : NatModule (Named name (List T × List T')) :=
@@ -171,7 +171,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     outputs := [
       (0, ⟨ T × T', λ ol el nl => ol.1 = el.1 :: nl.1 ∧ ol.2 = el.2 :: nl.2 ⟩),
     ].toAssocList
-    initial_state := sorry,
+    init_state := sorry,
   }
 
 @[drunfold] def split T T' (name := "split") : NatModule (Named name (List T × List T')) :=
@@ -186,7 +186,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
       (1, ⟨ T', λ (oldListL, oldListR) oldElementR (newListL, newListR) =>
          oldListR = oldElementR :: newListR ∧ oldListL = newListL ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def branch T (name := "branch") : NatModule (Named name (List T × List Bool)) :=
@@ -203,7 +203,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
       (1, ⟨ T, λ (oldValList, oldBoolList) val (newValList, newBoolList) =>
         val :: newValList = oldValList ∧ false :: newBoolList = oldBoolList ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def mux T (name := "mux") : NatModule (Named name (List T × List T × List Bool)) :=
@@ -222,7 +222,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
         ∧ if b then val :: newTrueList = oldTrueList ∧ newFalseList = oldFalseList
          else newTrueList = oldTrueList ∧ val :: newFalseList = oldFalseList ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], [], []⟩,
+    init_state := λ s => s = ⟨[], [], []⟩,
   }
 
 @[drunfold] def muxC T (name := "muxC") : NatModule (Named name (List T × List T × List Bool)) :=
@@ -241,7 +241,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
         ∧ if b then val :: newTrueList = oldTrueList ∧ newFalseList = oldFalseList
         else newTrueList = oldTrueList ∧ val :: newFalseList = oldFalseList ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], [], []⟩,
+    init_state := λ s => s = ⟨[], [], []⟩,
   }
 
 @[drunfold] def joinC T T' T'' (name := "joinC") : NatModule (Named name (List T × List (T'× T''))) :=
@@ -256,14 +256,14 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
       (0, ⟨ T × T', λ (oldListL, oldListR) (oldElementL, oldElementR) (newListL, newListR) =>
          ∃ x, oldListL =  oldElementL :: newListL ∧ oldListR = (oldElementR, x) :: newListR ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def empty (name := "empty") : NatModule (Named name Unit) :=
   {
     inputs := AssocList.nil,
     outputs := AssocList.nil,
-    initial_state := λ _ => True,
+    init_state := λ _ => True,
   }
 
 @[drunfold] def bag T (name := "bag") : NatModule (Named name (List T)) :=
@@ -274,7 +274,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
     outputs := [
       (0, ⟨ T, λ oldList oldElement newList => ∃ i, newList = oldList.remove i ∧ oldElement = oldList.get i ⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def tagger_untagger (TagT : Type 0) [_i: DecidableEq TagT] (T : Type 0) (name := "tagger_untagger") : NatModule (Named name (List TagT × (AssocList TagT T))) :=
@@ -299,7 +299,7 @@ def cons_n {T} (n : Nat) (l : List (List T)) (t : T) : Option (List (List T)) :=
         ∃ l tag , oldorder = l.cons tag ∧ oldmap.find? tag = some el ∧
         newmap = oldmap.eraseAll tag ∧ neworder = l ⟩),
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], AssocList.nil⟩,
+    init_state := λ s => s = ⟨[], AssocList.nil⟩,
   }
 
 /--
@@ -334,7 +334,7 @@ Essentially tagger + join without internal rule
         ∃ tag , oldorder = tag :: neworder ∧ oldmap.find? tag = some el ∧
         newmap = oldmap.eraseAll tag ∧ newVal = oldVal ⟩),
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], AssocList.nil, []⟩,
+    init_state := λ s => s = ⟨[], AssocList.nil, []⟩,
   }
 
 @[drunfold] def tagger (TagT : Type) [DecidableEq TagT] T (name := "tagger") : NatModule (Named name (List (TagT × T) × List TagT)) :=
@@ -351,7 +351,7 @@ Essentially tagger + join without internal rule
       (0, ⟨ TagT × T, λ (oldEl, oldOrder) el (newEl, newOrder) =>
         el :: newEl = oldEl ∧ newOrder = oldOrder⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def aligner TagT [DecidableEq TagT] T (name := "aligner") : NatModule (Named name (List (TagT × T) × List (TagT × T))) :=
@@ -369,14 +369,14 @@ Essentially tagger + join without internal rule
            ∧ newListR = oldListR.eraseP (·.fst = t)
            ∧ oldElement = ((t, v), (t, v')) ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def sink (T : Type _) (name := "sink") : NatModule (Named name Unit) :=
   {
     inputs := [(0, ⟨ T, λ _ _ _ => True ⟩)].toAssocList,
     outputs := ∅
-    initial_state := λ _ => True,
+    init_state := λ _ => True,
   }
 
 @[drunfold] def unary_op {α R} (f : α → R) (name := "unary_op"): NatModule (Named name (List α)) :=
@@ -387,7 +387,7 @@ Essentially tagger + join without internal rule
     outputs := [
       (0, ⟨ R, λ oldList oldElement newList => ∃ a, a :: newList = oldList ∧ oldElement = f a ⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def binary_op {α β R} (f : α → β → R) (name := "binary_op"): NatModule (Named name (List α × List β)) :=
@@ -400,7 +400,7 @@ Essentially tagger + join without internal rule
       (0, ⟨ R, λ ol el nl =>
         ∃ a b, ol.1 = a :: nl.1 ∧ ol.2 = b :: nl.2 ∧ el = f a b ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def ternary_op {α β γ R} (f : α → β → γ → R) (name := "ternary_op"): NatModule (Named name (List α × List β × List γ)) :=
@@ -414,7 +414,7 @@ Essentially tagger + join without internal rule
       (0, ⟨ R, λ ol el nl =>
         ∃ a b g, ol.1 = a :: nl.1 ∧ ol.2.1 = b :: nl.2.1 ∧ ol.2.2 = g :: nl.2.2 ∧ el = f a b g ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], [], []⟩
+    init_state := λ s => s = ⟨[], [], []⟩
   }
 
 @[drunfold] def constant {T} (t : T) (name := "constant") : NatModule (Named name (List Unit)) :=
@@ -425,7 +425,7 @@ Essentially tagger + join without internal rule
     outputs := [
       (0, ⟨ T, λ oldList oldElement newList => ∃ a, a :: newList = oldList ∧ oldElement = t ⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 @[drunfold] def sync {T S} (name := "sync") : NatModule (Named name (List S × List T)) :=
@@ -437,7 +437,7 @@ Essentially tagger + join without internal rule
     outputs := [
       (0, ⟨ T, λ (lo, ro) t (ln, rn) => ∃ s, lo = s :: ln ∧ ro = t :: rn ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def sync1 {T S} (name := "sync1") : NatModule (Named name (Option S × List T)) :=
@@ -449,7 +449,7 @@ Essentially tagger + join without internal rule
     outputs := [
       (0, ⟨ T, λ (lo, ro) t (ln, rn) => ∃ s, lo = some s ∧ ln = none ∧ ro = t :: rn ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨none, []⟩,
+    init_state := λ s => s = ⟨none, []⟩,
   }
 
 @[drunfold] def dsync {T S} (f : T → S) (name := "dsync") : NatModule (Named name (List S × List T)) :=
@@ -461,7 +461,7 @@ Essentially tagger + join without internal rule
       (0, ⟨ S, λ (lo, ro) s (ln, rn) => lo = s :: ln ⟩),
       (1, ⟨ T, λ (lo, ro) t (ln, rn) => ro = t :: rn ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def dsyncU {T} (name := "dsyncU") : NatModule (Named name (List Unit × List T)) :=
@@ -476,7 +476,7 @@ Essentially tagger + join without internal rule
       (0, ⟨ S, λ (lo, ro) s (ln, rn) => lo = some s ∧ ln = none ⟩),
       (1, ⟨ T, λ (lo, ro) t (ln, rn) => ro = t :: rn ⟩)
     ].toAssocList,
-    initial_state := λ s => s = ⟨none, []⟩,
+    init_state := λ s => s = ⟨none, []⟩,
   }
 
 @[drunfold] def dsync1U {T} (name := "dsync1U") : NatModule (Named name (Option Unit × List T)) :=
@@ -492,7 +492,7 @@ Essentially tagger + join without internal rule
       (0, ⟨S, λ before el after => el :: after.1 = before.1 ∧ after.2 = before.2⟩),
       (1, ⟨T, λ before el after => el :: after.2 = before.2 ∧ after.1 = before.1⟩),
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], []⟩,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 @[drunfold] def pure {S T} (f : S → T) (name := "pure") : NatModule (Named name (List T)) :=
@@ -503,7 +503,7 @@ Essentially tagger + join without internal rule
     outputs := [
       (0, ⟨T, λ before el after => el :: after = before⟩)
     ].toAssocList,
-    initial_state := λ s => s = [],
+    init_state := λ s => s = [],
   }
 
 section
@@ -564,7 +564,7 @@ def BoundedList T n := { ls : List T // ls.length <= n }
         oldListL.val = newListL.val.concat oldElementL
         ∧ oldListR.val = newListR.val.concat oldElementR ⟩)
     ].toAssocList,
-    initial_state := sorry,
+    init_state := sorry,
   }
 
 @[drunfold] def joinL T T' T'' n : NatModule (BoundedList (T × T') n × BoundedList T'' n) :=
@@ -580,7 +580,7 @@ def BoundedList T n := { ls : List T // ls.length <= n }
         oldListL.val = newListL.val.concat (oldElementL₁, oldElementL₂)
         ∧ oldListR.val = newListR.val.concat oldElementR⟩)
     ].toAssocList,
-    initial_state := sorry,
+    init_state := sorry,
   }
 
 end FixedSize

--- a/DataflowRewriter/Component.lean
+++ b/DataflowRewriter/Component.lean
@@ -165,7 +165,7 @@ def init T (default : T) (name := "init") : NatModule (Named name (List T × Boo
       else
         newList = oldList ∧ newState = true ∧ oldElement = default ⟩)
     ].toAssocList,
-    init_state := sorry,
+    init_state := λ s => s = ⟨[], false⟩,
   }
 
 @[drunfold]

--- a/DataflowRewriter/Examples/NoC/Basic.lean
+++ b/DataflowRewriter/Examples/NoC/Basic.lean
@@ -4,10 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yann Herklotz, Gurvan Debaussart
 -/
 
--- Implementation of NoC types and reference implementation using Bags
--- Inputs are defined as a product between an arbitrary type T and a FlitHeader
--- type, which gives information about the desired target of each message.
-
 namespace DataflowRewriter.NoC
 
 -- TODO: Maybe a comment here to explain Yann's hack would be great since this

--- a/DataflowRewriter/Examples/NoC/Components.lean
+++ b/DataflowRewriter/Examples/NoC/Components.lean
@@ -51,6 +51,7 @@ def nbranch' (name := "nbranch") : NatModule (NatModule.Named name (List P.Data 
             { dest := routerID } :: newRouterIDs = oldRouterIDs
         ⟩)
       |>.toAssocList,
+    init_state := λ s => s = ⟨[], []⟩,
   }
 
 def nrouteT := List (P.Data × FlitHeader)
@@ -66,12 +67,11 @@ def mk_nroute_output_rule (rID : RouterID) : (Σ T : Type, nrouteT → T → nro
 def nroute' (name := "nroute") : NatModule (NatModule.Named name nrouteT) :=
   {
     inputs := [
-      (0, ⟨
-        P.Data × FlitHeader,
-        λ oldState v newState => newState = oldState.concat v
-      ⟩),
+      (0, ⟨P.Data × FlitHeader,
+        λ oldState v newState => newState = oldState.concat v⟩),
     ].toAssocList,
     outputs := List.range P.netsz |>.map (lift_f mk_nroute_output_rule) |>.toAssocList
+    init_state := λ s => s = [],
   }
 
 def mk_nbag_input_rule (S : Type) (_ : Nat) : (Σ T : Type, List S → T → List S → Prop) :=
@@ -82,7 +82,11 @@ def mk_nbag_input_rule (S : Type) (_ : Nat) : (Σ T : Type, List S → T → Lis
 def nbag' (T : Type) (n : Nat) (name := "nbag") : NatModule (NatModule.Named name (List T)) :=
   {
     inputs := List.range n |>.map (lift_f (mk_nbag_input_rule T)) |>.toAssocList,
-    outputs := [(↑0, ⟨ T, λ oldState v newState => ∃ i, newState = oldState.remove i ∧ v = oldState.get i ⟩)].toAssocList,
+    outputs := [
+      (↑0, ⟨ T, λ oldState v newState =>
+        ∃ i, newState = oldState.remove i ∧ v = oldState.get i ⟩)
+    ].toAssocList,
+    init_state := λ s => s = [],
   }
 
 def nocT : Type :=
@@ -108,6 +112,7 @@ def noc' (name := "noc") : NatModule (NatModule.Named name nocT) :=
   {
     inputs := List.range P.netsz |>.map (lift_f mk_noc_input_rule) |>.toAssocList,
     outputs := List.range P.netsz |>.map (lift_f mk_noc_output_rule) |>.toAssocList,
+    init_state := λ s => s = [],
   }
 
 -- Stringify -------------------------------------------------------------------

--- a/DataflowRewriter/Examples/NoC/ComponentsImplementation/NBag.lean
+++ b/DataflowRewriter/Examples/NoC/ComponentsImplementation/NBag.lean
@@ -170,7 +170,13 @@ instance : MatchInterface nbag_lowM (nbag P.Data P.netsz) where
 def φ (I : nbag_lowT) (S : List P.Data) : Prop :=
   S = I.fst ++ I.snd
 
-theorem nbag_low_correctϕ : nbag_lowM ⊑_{φ} (nbag P.Data P.netsz) := by
+theorem nbag_low_initial_φ :
+  Module.refines_initial nbag_lowM (nbag P.Data P.netsz) φ := by
+    intros i Hi; exists []; split_ands
+    · simpa [drunfold, Module.mapIdent]
+    · unfold φ; simpa [Hi]
+
+theorem nbag_low_refines_ϕ : nbag_lowM ⊑_{φ} (nbag P.Data P.netsz) := by
   intros i s H
   constructor
   · intro ident mid_i v Hrule
@@ -221,7 +227,7 @@ theorem nbag_low_correctϕ : nbag_lowM ⊑_{φ} (nbag P.Data P.netsz) := by
       subst a b s
       simpa [H4, H2]
 
-theorem nbag_low_ϕ_indistinguishable :
+theorem nbag_low_indistinguishable_φ :
   ∀ x y, φ x y → Module.indistinguishable nbag_lowM (nbag P.Data P.netsz) x y := by
     intros x y Hϕ
     constructor
@@ -261,6 +267,6 @@ theorem nbag_low_ϕ_indistinguishable :
         apply (PortMap.getIO_cons_nil_false _ _ ident _ _ _ Hident H)
 
 theorem nbag_low_correct : nbag_lowM ⊑ (nbag P.Data P.netsz) := by
-  apply (Module.refines_φ_refines nbag_low_ϕ_indistinguishable nbag_low_correctϕ)
+  apply (Module.refines_φ_refines nbag_low_indistinguishable_φ nbag_low_initial_φ nbag_low_refines_ϕ)
 
 end DataflowRewriter.NoC

--- a/DataflowRewriter/Examples/NoC/ComponentsImplementation/NRoute.lean
+++ b/DataflowRewriter/Examples/NoC/ComponentsImplementation/NRoute.lean
@@ -183,7 +183,11 @@ def φ (I : nroute_lowT) (S : nrouteT) : Prop :=
   List.map Prod.fst S = I.1.1 ++ I.2.1 ∧
   List.map Prod.snd S = I.1.2 ++ I.2.2
 
-theorem nroute_low_correctϕ : nroute_lowM ⊑_{φ} nroute := by
+theorem nroute_low_refines_initial :
+  Module.refines_initial nroute_lowM nroute φ := by
+    sorry
+
+theorem nroute_low_refines_φ : nroute_lowM ⊑_{φ} nroute := by
   intros i s H
   constructor
   · intro ident mid_i v Hrule
@@ -214,6 +218,6 @@ theorem nroute_low_ϕ_indistinguishable :
     sorry
 
 theorem nroute_low_correct : nroute_lowM ⊑ nroute := by
-  apply (Module.refines_φ_refines nroute_low_ϕ_indistinguishable nroute_low_correctϕ)
+  apply (Module.refines_φ_refines nroute_low_ϕ_indistinguishable nroute_low_refines_initial nroute_low_refines_φ)
 
 end DataflowRewriter.NoC

--- a/DataflowRewriter/Module.lean
+++ b/DataflowRewriter/Module.lean
@@ -145,7 +145,8 @@ theorem connect''_dep_rw {C : Type} {x y x' y' : Σ (T : Type), C → T → C �
     @Module.connect'' y.1 x.1 C x.2 y.2 = @Module.connect'' y'.1 x'.1 C x'.2 y'.2 := by
   intros; subst_vars; rfl
 
-@[drunfold] def product {S S'} (mod1 : Module Ident S) (mod2: Module Ident S') : Module Ident (S × S') :=
+@[drunfold]
+def product {S S'} (mod1 : Module Ident S) (mod2: Module Ident S') : Module Ident (S × S') :=
   {
     inputs := (mod1.inputs.mapVal (λ _ => liftL)).append (mod2.inputs.mapVal (λ _ => liftR)),
     outputs := (mod1.outputs.mapVal (λ _ => liftL)).append (mod2.outputs.mapVal (λ _ => liftR)),
@@ -155,7 +156,8 @@ theorem connect''_dep_rw {C : Type} {x y x' y' : Σ (T : Type), C → T → C �
 
 def NamedProduct (s : String) T₁ T₂ := T₁ × T₂
 
-@[drunfold] def named_product {S S'} (mod1 : Module Ident S) (mod2: Module Ident S') (str : String := "") : Module Ident (NamedProduct str S S') :=
+@[drunfold]
+def named_product {S S'} (mod1 : Module Ident S) (mod2: Module Ident S') (str : String := "") : Module Ident (NamedProduct str S S') :=
   {
     inputs := (mod1.inputs.mapVal (λ _ => liftL)).append (mod2.inputs.mapVal (λ _ => liftR)),
     outputs := (mod1.outputs.mapVal (λ _ => liftL)).append (mod2.outputs.mapVal (λ _ => liftR)),
@@ -163,7 +165,8 @@ def NamedProduct (s : String) T₁ T₂ := T₁ × T₂
     init_state := λ (s, s') => mod1.init_state s ∧ mod2.init_state s',
   }
 
-@[drunfold] def productD {α} {l₁ l₂ : List α} {f} (mod1 : Module Ident (HVector f l₁)) (mod2: Module Ident (HVector f l₂)) : Module Ident (HVector f (l₁ ++ l₂)) :=
+@[drunfold]
+def productD {α} {l₁ l₂ : List α} {f} (mod1 : Module Ident (HVector f l₁)) (mod2: Module Ident (HVector f l₂)) : Module Ident (HVector f (l₁ ++ l₂)) :=
   {
     inputs := (mod1.inputs.mapVal (λ _ => liftLD)).append (mod2.inputs.mapVal (λ _ => liftRD)),
     outputs := (mod1.outputs.mapVal (λ _ => liftLD)).append (mod2.outputs.mapVal (λ _ => liftRD)),
@@ -171,7 +174,8 @@ def NamedProduct (s : String) T₁ T₂ := T₁ × T₂
     init_state := sorry -- TODO
   }
 
-@[drunfold] def liftD {α} {e : α} {f} (mod : Module Ident (f e)) : Module Ident (HVector f [e]) :=
+@[drunfold]
+def liftD {α} {e : α} {f} (mod : Module Ident (f e)) : Module Ident (HVector f [e]) :=
   {
     inputs := mod.inputs.mapVal λ _ => liftSingle,
     outputs := mod.outputs.mapVal λ _ => liftSingle,
@@ -179,16 +183,20 @@ def NamedProduct (s : String) T₁ T₂ := T₁ × T₂
     init_state := sorry -- TODO
   }
 
-@[drunfold] def mapInputPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
+@[drunfold]
+def mapInputPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
   { mod with inputs := mod.inputs.mapKey f }
 
-@[drunfold] def mapOutputPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
+@[drunfold]
+def mapOutputPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
   { mod with outputs := mod.outputs.mapKey f }
 
-@[drunfold] def mapPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
+@[drunfold]
+def mapPorts {S} (mod : Module Ident S) (f : InternalPort Ident → InternalPort Ident) : Module Ident S :=
   mod.mapInputPorts f |>.mapOutputPorts f
 
-@[drunfold] def mapPorts2 {S} (mod : Module Ident S) (f g : InternalPort Ident → InternalPort Ident) : Module Ident S :=
+@[drunfold]
+def mapPorts2 {S} (mod : Module Ident S) (f g : InternalPort Ident → InternalPort Ident) : Module Ident S :=
   mod.mapInputPorts f |>.mapOutputPorts g
 
 -- #eval (bijectivePortRenaming (Ident := Nat) [(⟨.top, 1⟩, ⟨.top, 2⟩), (⟨.top, 4⟩, ⟨.top, 3⟩)].toAssocList) ⟨.top, 3⟩
@@ -715,6 +723,13 @@ variable (smod : Module Ident S)
 def refines_initial [mm : MatchInterface imod smod] (R : I → S → Prop) :=
   ∀ i, imod.init_state i → ∃ s, smod.init_state s ∧ R i s
 
+theorem refines_initial_reflexive_ext
+  imod' (h : imod.EqExt imod') (mm := MatchInterface_EqExt h) φ (Hφ : ∀ i, φ i i):
+    refines_initial imod imod' φ := by
+  intros i Hi; exists i
+  obtain ⟨_, _, _, h⟩ := h
+  split_ands <;> simpa [←h, Hφ]
+
 def refines :=
   ∃ (mm : MatchInterface imod smod) (R : I → S → Prop),
     (imod ⊑_{fun x y => indistinguishable imod smod x y ∧ R x y} smod)
@@ -787,16 +802,15 @@ theorem refines_reflexive : imod ⊑ imod := by
 theorem refines_reflexive_ext imod' (h : imod.EqExt imod') : imod ⊑ imod' := by
   have _ := MatchInterface_EqExt h
   apply refines_φ_refines (φ := Eq) (smod := imod'); intros; subst_vars
-  all_goals sorry
-  -- all_goals solve_by_elim [indistinguishable_reflexive_ext, refines_φ_reflexive_ext]
+  all_goals solve_by_elim [indistinguishable_reflexive_ext, refines_φ_reflexive_ext, refines_initial_reflexive_ext]
 
 theorem refines_transitive {J} (imod' : Module Ident J):
     imod ⊑ imod' →
     imod' ⊑ smod →
     imod ⊑ smod := by
   intro h1 h2
-  rcases h1 with ⟨ mm1, R1, h1 ⟩
-  rcases h2 with ⟨ mm2, R2, h2 ⟩
+  rcases h1 with ⟨ mm1, R1, h11, h12 ⟩
+  rcases h2 with ⟨ mm2, R2, h21, h22 ⟩
   have mm3 := MatchInterface_transitive imod' mm1 mm2
   constructor <;> try assumption
   exists (fun a b => ∃ c, (imod.indistinguishable imod' a c ∧ R1 a c)
@@ -812,9 +826,15 @@ theorem refines_transitive {J} (imod' : Module Ident J):
     constructor; rotate_left; tauto
     apply indistinguishable_transitive imod smod imod' <;> tauto
   rw [this]
-  sorry
-  -- apply refines_φ_transitive imod smod imod'
-  -- assumption; assumption
+  split_ands
+  · apply refines_φ_transitive imod smod imod'
+    assumption; assumption
+  · intros _ Hi; dsimp;
+    obtain ⟨i', Hi', _⟩ := h12 _ Hi
+    obtain ⟨s, _, _⟩ := h22 _ Hi'
+    exists s
+    split_ands <;> try assumption
+    exists i'
 
 axiom indistinguishability_product {J K} {i i₂ s s₂} {imod₂ : Module Ident J} {smod₂ : Module Ident K}
   [MatchInterface imod smod]

--- a/DataflowRewriter/Rewrites/BagQueueCorrect.lean
+++ b/DataflowRewriter/Rewrites/BagQueueCorrect.lean
@@ -38,9 +38,12 @@ instance : MatchInterface (queue T₁) (bag T₁) where
     intros ident;
     unfold queue bag
     by_cases ({ inst := InstIdent.top, name := 0 }: InternalPort Nat) = ident
-    <;> simpa [*]
+    <;> simpa [*, drunfold, drnat]
 
 def φ (I S : List T₁) : Prop := I = S
+
+theorem φ_initial : Module.refines_initial (queue T₁) (bag T₁) φ := by
+  intros i _; exists i
 
 theorem queue_refine_ϕ_bag: queue T₁ ⊑_{φ} bag T₁ := by
   prove_refines_φ (queue T₁)
@@ -80,6 +83,6 @@ theorem ϕ_indistinguishable:
         · exact H
 
 theorem queue_refine_bag: queue T₁ ⊑ bag T₁ := by
-  apply (Module.refines_φ_refines ϕ_indistinguishable queue_refine_ϕ_bag)
+  apply (Module.refines_φ_refines ϕ_indistinguishable φ_initial queue_refine_ϕ_bag)
 
 end DataflowRewriter.BagQueue

--- a/DataflowRewriter/Rewrites/LoopRewrite.lean
+++ b/DataflowRewriter/Rewrites/LoopRewrite.lean
@@ -223,33 +223,35 @@ def rewrite : Rewrite String :=
 Essentially tagger + join without internal rule
 -/
 @[drunfold] def NatModule.tagger_untagger_val_ghost (TagT : Type 0) [_i: DecidableEq TagT] (T : Type 0) (name := "tagger_untagger_val_ghost") : NatModule (NatModule.Named name (List (TagT × T) × Batteries.AssocList TagT (T × (Nat × T)) × List (T × (Nat × T)))) :=
-  { inputs := [
-        -- Complete computation
-        -- Models the input of the Cal + Untagger (coming from a previously tagged region)
-        (0, ⟨ (TagT × T) × (Nat × T), λ (oldOrder, oldMap, oldVal) ((tag,el), r) (newOrder, newMap, newVal) =>
-          -- Tag must be used, but no value ready, otherwise block:
-          (tag ∈ oldOrder.map Prod.fst ∧ oldMap.find? tag = none) ∧
-          newMap = oldMap.cons tag (el, r) ∧ newOrder = oldOrder ∧ newVal = oldVal ⟩),
-        -- Enq a value to be tagged
-        -- Models the input of the Tagger (coming from outside)
-        (1, ⟨ T, λ (oldOrder, oldMap, oldVal) v (newOrder, newMap, newVal) =>
-          newMap = oldMap ∧ newOrder = oldOrder ∧ newVal = oldVal.concat (v, 0, v) ⟩)
-      ].toAssocList,
+  {
+    inputs := [
+      -- Complete computation
+      -- Models the input of the Cal + Untagger (coming from a previously tagged region)
+      (0, ⟨ (TagT × T) × (Nat × T), λ (oldOrder, oldMap, oldVal) ((tag,el), r) (newOrder, newMap, newVal) =>
+        -- Tag must be used, but no value ready, otherwise block:
+        (tag ∈ oldOrder.map Prod.fst ∧ oldMap.find? tag = none) ∧
+        newMap = oldMap.cons tag (el, r) ∧ newOrder = oldOrder ∧ newVal = oldVal ⟩),
+      -- Enq a value to be tagged
+      -- Models the input of the Tagger (coming from outside)
+      (1, ⟨ T, λ (oldOrder, oldMap, oldVal) v (newOrder, newMap, newVal) =>
+        newMap = oldMap ∧ newOrder = oldOrder ∧ newVal = oldVal.concat (v, 0, v) ⟩)
+    ].toAssocList,
     outputs := [
-        -- Allocate fresh tag and output with value
-        -- Models the output of the Tagger
+      -- Allocate fresh tag and output with value
+      -- Models the output of the Tagger
       (0, ⟨ (TagT × T) × (Nat × T), λ (oldOrder, oldMap, oldVal) ((tag, v), z) (newOrder, newMap, newVal) =>
         -- Tag must be unused otherwise block (alternatively we
         -- could an implication to say undefined behavior):
         (tag ∉ oldOrder.map Prod.fst ∧ oldMap.find? tag = none) ∧
         newMap = oldMap ∧ newOrder = oldOrder.concat (tag, v) ∧ (v, z) :: newVal = oldVal⟩),
-        -- Dequeue + free tag
-        -- Models the output of the Cal + Untagger
+      -- Dequeue + free tag
+      -- Models the output of the Cal + Untagger
       (1, ⟨ T, λ (oldorder, oldmap, oldVal) el (neworder, newmap, newVal) =>
         -- tag must be used otherwise, but no value brought, undefined behavior:
         ∃ tag r, oldorder = tag :: neworder ∧ oldmap.find? tag.fst = some (el, r) ∧
         newmap = oldmap.eraseAll tag.fst ∧ newVal = oldVal ⟩),
-        ].toAssocList
+    ].toAssocList,
+    initial_state := λ s => s = ⟨[], Batteries.AssocList.nil, []⟩,
   }
 
 @[drunfold] def StringModule.tagger_untagger_val_ghost TagT [DecidableEq TagT] T :=

--- a/DataflowRewriter/Rewrites/LoopRewrite.lean
+++ b/DataflowRewriter/Rewrites/LoopRewrite.lean
@@ -251,7 +251,7 @@ Essentially tagger + join without internal rule
         ∃ tag r, oldorder = tag :: neworder ∧ oldmap.find? tag.fst = some (el, r) ∧
         newmap = oldmap.eraseAll tag.fst ∧ newVal = oldVal ⟩),
     ].toAssocList,
-    initial_state := λ s => s = ⟨[], Batteries.AssocList.nil, []⟩,
+    init_state := λ s => s = ⟨[], Batteries.AssocList.nil, []⟩,
   }
 
 @[drunfold] def StringModule.tagger_untagger_val_ghost TagT [DecidableEq TagT] T :=


### PR DESCRIPTION
We can currently prove refinement between any two modules by using $\varphi x y = False$. This is due to the fact that we don't ever require proving that the $\varphi$ properties holds at any point.

This PR therefore add an initial state to module semantics and require us to prove that the $\varphi$ holds for this initial state.